### PR TITLE
Add a Circle CI config file that lints the Golang code with revive.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  go-lint:
+    docker:  # run the steps with Docker
+      # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
+      - image: circleci/golang:1.14
+    # directory where steps are run. Path must conform to the Go Workspace requirements
+    working_directory: /go/src/github.com/DonyaOS/PackageManager
+    steps:
+      - checkout
+      - restore_cache:  # restores saved cache if no changes are detected since last run
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          keys:
+            - v1-pkg-cache
+      - run: go get -u github.com/mgechev/revive
+      - run:
+          name: 🧹 Run Golang revive lint
+          command: |
+            sh ./revive.sh || exit 1
+      - save_cache:  # Store cache in the /go/pkg directory
+          key: v1-pkg-cache
+          paths:
+            - "/go/pkg"

--- a/.yamllint
+++ b/.yamllint
@@ -4,4 +4,6 @@ extends: default
 
 rules:
   document-start: disable
+  line-length:
+    max: 90
   truthy: disable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,22 @@ To build the Go file into an executable for Linux run:
 go build src/donya.go
 ```
 
-And for Windows:
+And generally for Windows:
 
 ```
 env GOOS=windows GOARCH=amd64 go build src/donya.go
+```
+
+To see all the platforms run:
+
+```
+go tool dist list -json
+```
+
+You can install `revive` with:
+
+```
+go get -u github.com/mgechev/revive
 ```
 
 - [Go](https://golang.org/) - Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.

--- a/lint.sh
+++ b/lint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-markdownlint '**/*.md' --ignore node_modules
+markdownlint '**/*.md' --ignore node_modules --fix
 yamllint .


### PR DESCRIPTION
Update the contributing guide.

Circle CI is free to start -> https://circleci.com/open-source/ and we just need a Linux VM

